### PR TITLE
add Mumubiz CZV20 water valve as whiteLabel of CK-BL702-MSW-01(7010)`

### DIFF
--- a/src/devices/ewelink.ts
+++ b/src/devices/ewelink.ts
@@ -22,7 +22,7 @@ interface EwelinkSiren {
         alarmSoundTime: number;
     };
     commands: never;
-    commandResponses: never;
+    commandsResponse: never;
 }
 
 const fzLocal = {
@@ -59,6 +59,26 @@ const tzLocal = {
             await entity.read("genOnOff", ["onOff"]);
         },
     } satisfies Tz.Converter,
+};
+
+const tzCountdownOnOff: Tz.Converter = {
+    key: ["countdown"],
+    convertSet: async (entity, key, value, meta) => {
+        const seconds = Math.round(Number(value));
+        if (seconds <= 0) {
+            await entity.command("genOnOff", "off", {}, {disableDefaultResponse: true});
+            return {state: {state: "OFF", countdown: 0}};
+        }
+        const onTimeRaw = Math.min(seconds * 10, 0xfffe);
+        const actualSeconds = Math.floor(onTimeRaw / 10);
+        await entity.command(
+            "genOnOff",
+            "onWithTimedOff",
+            {ctrlbits: 0, ontime: onTimeRaw, offwaittime: 0},
+            {disableDefaultResponse: true},
+        );
+        return {state: {state: "ON", countdown: actualSeconds}};
+    },
 };
 
 const ewelinkExtend = {
@@ -110,7 +130,33 @@ export const definitions: DefinitionWithExtend[] = [
         model: "CK-BL702-MSW-01(7010)",
         vendor: "eWeLink",
         description: "CMARS Zigbee smart plug",
-        extend: [m.onOff({skipDuplicateTransaction: true}), m.skipDefaultResponse()],
+        whiteLabel: [
+            {
+                vendor: "Mumubiz",
+                model: "CZV20",
+                description: "Zigbee smart water valve",
+                fingerprint: [
+                    {
+                        type: "Router",
+                        manufacturerName: "eWeLink",
+                        modelID: "CK-BL702-MSW-01(7010)",
+                        endpoints: [
+                            {ID: 1, inputClusters: [0, 3, 4, 5, 6, 4096, 61184, 64529, 64599]},
+                        ],
+                    },
+                ],
+            },
+        ],
+        extend: [m.onOff({powerOnBehavior: true, skipDuplicateTransaction: true}), m.skipDefaultResponse()],
+        toZigbee: [tzCountdownOnOff],
+        exposes: [
+            e.numeric("countdown", ea.STATE_SET)
+                .withUnit("s")
+                .withDescription("Countdown to turn device off after a certain time")
+                .withValueMin(0)
+                .withValueMax(6500)
+                .withValueStep(1),
+        ],
     },
     {
         zigbeeModel: ["SA-003-Zigbee"],


### PR DESCRIPTION
**What:**
Add Mumubiz CZV20 Zigbee smart water valve as a whiteLabel variant of the existing eWeLink CK-BL702-MSW-01(7010) CMARS smart plug.

Uses `whiteLabel` with `fingerprint` to differentiate the valve from the plug — the valve has `manuSpecificTuya` (0xEF00 / 61184) in its input clusters, which the plug does not.

Also adds:
- `countdown` expose: one-shot timer using ZCL `onWithTimedOff` command (runs on device firmware, no cloud dependency)
- `powerOnBehavior` support

**Link:** https://pt.aliexpress.com/item/1005007390108705.html

**Device info:**
- Vendor: Mumubiz
- Model: CZV20
- Zigbee Model: CK-BL702-MSW-01(7010)
- Available sizes: DN15 (1/2"), DN20 (3/4"), DN25 (1")

**Database entry:**
```json
{"id":62,"type":"Router","ieeeAddr":"0x7cb94c7816ba0000","nwkAddr":34945,"manufId":4742,"manufName":"eWeLink","powerSource":"Mains (single phase)","modelId":"CK-BL702-MSW-01(7010)","epList":[1,242],"endpoints":{"1":{"profId":260,"epId":1,"devId":2,"inClusterList":[0,3,4,5,6,4096,61184,64529,64599],"outClusterList":[25],"clusters":{"genBasic":{"attributes":{"stackVersion":0,"hwVersion":0,"zclVersion":8}},"genOnOff":{"attributes":{"onOff":0,"startUpOnOff":0}}},"binds":[{"cluster":6,"type":"endpoint","deviceIeeeAddress":"0x00124b00257ccc1d","endpointID":1}],"configuredReportings":[{"cluster":6,"attrId":0,"minRepIntval":0,"maxRepIntval":65000,"repChange":1}],"meta":{}},"242":{"profId":41440,"epId":242,"devId":97,"inClusterList":[],"outClusterList":[33],"clusters":{},"binds":[],"configuredReportings":[],"meta":{}}},"appVersion":1,"stackVersion":0,"hwVersion":0,"dateCode":"20210610-BL","swBuildId":"1.2.1","zclVersion":8,"interviewCompleted":true,"interviewState":"SUCCESSFUL","meta":{"configured":332242049},"lastSeen":1774637178230}
```

**Tested features:**
- [x] On/Off
- [x] Countdown timer (30s, 60s verified — firmware-level, no cloud)
- [x] Power-on behavior
- [x] State reporting

**Notes:**
The countdown feature uses standard ZCL `genOnOff.onWithTimedOff` and benefits both the plug and valve variants. The whiteLabel fingerprint discriminates the valve by the presence of `manuSpecificTuya` (61184) in its input cluster list.

<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
