### PR TITLE
fix: correct EwelinkSiren interface property name

### DIFF
--- a/src/devices/ewelink.ts
+++ b/src/devices/ewelink.ts
@@ -22,7 +22,7 @@ interface EwelinkSiren {
         alarmSoundTime: number;
     };
     commands: never;
-    commandsResponse: never;
+    commandResponses: never;
 }
 
 const fzLocal = {


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are adding support for a new device, please also submit a picture for the documentation.
Tutorial: https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_5-add-device-picture-to-zigbee2mqtt-io-documentation
The line below can be removed if you are NOT adding support for a new device.
-->
Link to picture pull request: TODO
